### PR TITLE
Allow __GNUC__ if desired by the user

### DIFF
--- a/ctypesgen/main.py
+++ b/ctypesgen/main.py
@@ -142,6 +142,17 @@ def main(givenargs=None):
         "necessary options (default: gcc -E)",
     )
     op.add_option(
+        "",
+        "--allow-gnu-c",
+        action="store_true",
+        dest="allow_gnu_c",
+        default=False,
+        help="Specify whether to undefine the '__GNUC__' macro, "
+        "while invoking the C preprocessor.\n"
+        "(default: False. i.e. ctypesgen adds an implicit undefine using '-U __GNUC__'.)\n"
+        "Specify this flag to avoid ctypesgen undefining '__GNUC__' as shown above.",
+    )
+    op.add_option(
         "-D",
         "--define",
         action="append",

--- a/ctypesgen/options.py
+++ b/ctypesgen/options.py
@@ -17,6 +17,7 @@ default_values = {
     "compile_libdirs": [],
     "runtime_libdirs": [],
     "cpp": "gcc -E",
+    "allow_gnu_c": False,
     "cpp_defines": [],
     "cpp_undefines": [],
     "save_preprocessed_headers": None,

--- a/ctypesgen/parser/preprocessor.py
+++ b/ctypesgen/parser/preprocessor.py
@@ -141,7 +141,19 @@ class PreprocessorParser(object):
         """Parse a file and save its output"""
 
         cmd = self.options.cpp
-        cmd += " -U __GNUC__ -dD"
+
+        # Legacy behaviour is to implicitly undefine '__GNUC__'
+        # Continue doing this, unless user explicitly requested to allow it.
+        if self.options.allow_gnu_c:
+            # New behaviour. No implicit override.
+            # (currently NOT enabled by default yet)
+            pass
+        else:
+            # Legacy behaviour. Add an implicit override.
+            # (currently the default)
+            cmd += " -U __GNUC__"
+
+        cmd += " -dD"
 
         for undefine in self.options.cpp_undefines:
             cmd += " -U%s" % undefine


### PR DESCRIPTION
Ctypesgen implicitly undefines '__GNUC__' while invoking the C preprocessor.
This interferes with parsing well-written code that contains gcc-specific
code within "#ifdef __GNUC__".

A common example is the "packed" attribute that ctypesgen supports parsing.
Currently all instances of "packed" defined within "#ifdef __GNUC__" are being
stripped-off when ctypesgen invokes the C preprocesser with -U __GNUC__.

This commit introduces a command-line parameter "--allow-gnu-c" that allows
the user of ctypesgen to override this legacy behaviour of ctypesgen.

This ensures that the default behaviour of ctypesgen remains unchanged.
Users of ctypesgen who require "__GNUC__" to continue to be defined when
ctypesgen parses their code, can invoke it as "ctypesgen --allow-gnu-c ..."

NOTE: It is not clear why specifying -D __GNUC__ does NOT override the implicit
-U __GNUC__ i.e. it still results in __GNUC__ NOT being defined. This is likely
a result of the order in which the define/undefine are passed/processed.
Instead of toying with the order in the parser code to achieve the desired
behaviour, this change introduces the new parameter "--allow-gnu-c" to enable
the user of ctypesgen to explicitly and reliably control the desired behaviour.