### PR TITLE
Use raw strings for regular expressions

### DIFF
--- a/ctypesgen/parser/pplexer.py
+++ b/ctypesgen/parser/pplexer.py
@@ -62,13 +62,13 @@ tokens = (
 states = [("DEFINE", "exclusive"), ("PRAGMA", "exclusive")]
 
 subs = {
-    "D": "[0-9]",
-    "L": "[a-zA-Z_]",
-    "H": "[a-fA-F0-9]",
-    "E": "[Ee][+-]?\s*{D}+",
+    "D": r"[0-9]",
+    "L": r"[a-zA-Z_]",
+    "H": r"[a-fA-F0-9]",
+    "E": r"[Ee][+-]?\s*{D}+",
     # new float suffixes supported in gcc 7
-    "FS": "([FflL]|D[FDL]|[fF]\d+x?)",
-    "IS": "[uUlL]*",
+    "FS": r"([FflL]|D[FDL]|[fF]\d+x?)",
+    "IS": r"[uUlL]*",
 }
 # Helper: substitute {foo} with subs[foo] in string (makes regexes more lexy)
 sub_pattern = re.compile("{([^}]*)}")

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -23,7 +23,7 @@ def get_preamble(major=None, minor=None):
     """get the available preambles"""
     preambles = dict()
     for fp in glob.glob(PREAMBLE_PATH):
-        m = re.search("(\d)_(\d).py$", fp)
+        m = re.search(r"(\d)_(\d).py$", fp)
         if not m:
             continue
         preambles[(int(m.group(1)), int(m.group(2)))] = fp


### PR DESCRIPTION
Addresses Python "DeprecationWarning: invalid escape sequence".

From CI test log:
```
=============================== warnings summary ===============================
ctypesgen/parser/pplexer.py:68
  /home/travis/build/ctypesgen/ctypesgen/ctypesgen/test/../../ctypesgen/parser/pplexer.py:68: DeprecationWarning: invalid escape sequence \s
    "E": "[Ee][+-]?\s*{D}+",

ctypesgen/parser/pplexer.py:70
  /home/travis/build/ctypesgen/ctypesgen/ctypesgen/test/../../ctypesgen/parser/pplexer.py:70: DeprecationWarning: invalid escape sequence \d
    "FS": "([FflL]|D[FDL]|[fF]\d+x?)",

ctypesgen/printer_python/printer.py:26
  /home/travis/build/ctypesgen/ctypesgen/ctypesgen/test/../../ctypesgen/printer_python/printer.py:26: DeprecationWarning: invalid escape sequence \d
    m = re.search("(\d)_(\d).py$", fp)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```