### PR TITLE
Add CI tests for more Python versions

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   flake8:
     name: ${{ matrix.directory }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  setup-and-test:
+    name: Python-${{ matrix.python }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            include:
+            # Linux
+            - os: ubuntu-latest
+              python: 3.7
+            - os: ubuntu-latest
+              python: 3.8
+            - os: ubuntu-latest
+              python: 3.9
+            - os: ubuntu-latest
+              python: "3.10"
+            # macOS
+            - os: macos-latest
+              python: "3.10"
+        fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run Test
+        run: |
+          pytest -v --showlocals ctypesgen/test/testsuite.py


### PR DESCRIPTION
Run the test suite on Python 3.7-3.10 on Ubuntu, as well as Python 3.10 on macOS.

Tests on Windows fail spectacularly, so I leave this for now.