### PR TITLE
Move test directory to root directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
 
       - name: Run Test
         run: |
-          pytest -v --showlocals ctypesgen/test/testsuite.py
+          pytest -v --showlocals tests/testsuite.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ build/
 ctypesgen.egg-info/
 .eggs/
 .python-version
-ctypesgen/test/.python-version
+tests/.python-version
 
 # Swap/backup editor files
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ jobs:
       install:
         - pip install --index-url https://test.pypi.org/simple/ --no-deps ctypesgen
       script:
-        - python -c 'import ctypesgencore; print(ctypesgencore.VERSION)'
+        - python -c 'import ctypesgen; print(ctypesgen.VERSION)'

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 temp.h
 temp.py
+common/

--- a/tests/ctypesgentest.py
+++ b/tests/ctypesgentest.py
@@ -16,13 +16,8 @@ import types
 import subprocess
 from shutil import rmtree
 
-
-# ensure that we can load the ctypesgen library
-PACKAGE_DIR = os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
-sys.path.insert(0, PACKAGE_DIR)
-
-from ctypesgen import options, messages, parser, processor  # noqa: E402
-from ctypesgen import printer_python, printer_json, VERSION  # noqa: E402
+from ctypesgen import options, messages, parser, processor
+from ctypesgen import printer_python, printer_json, VERSION
 
 module_factory = types.ModuleType
 

--- a/tests/testsuite.py
+++ b/tests/testsuite.py
@@ -4,11 +4,18 @@ By clach04 (Chris Clark).
 
 Calling:
 
-    python test/testsuite.py
+    python3 -m unittest tests.testsuite
+
+    Calling a specific test only:
+
+    python3 -m unittest tests.testsuite.[TestCase class].[test name]
+    e.g.:
+    python3 -m unittest tests.testsuite.StdBoolTest.test_stdbool_type
 
 or
-    cd test
-    ./testsuite.py
+    pytest -v  --showlocals tests/testsuite.py
+
+    pytest -v  --showlocals tests/testsuite.py::StdBoolTest::test_stdbool_type
 
 Could use any unitest compatible test runner (nose, etc.)
 
@@ -25,11 +32,7 @@ import unittest
 import logging
 from subprocess import Popen, PIPE
 
-test_directory = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(test_directory)
-sys.path.append(os.path.join(test_directory, os.pardir))
-
-from ctypesgentest import (  # noqa: E402
+from tests.ctypesgentest import (
     cleanup,
     cleanup_common,
     ctypesgen_version,
@@ -38,6 +41,8 @@ from ctypesgentest import (  # noqa: E402
     JsonHelper,
     set_logging_level,
 )
+
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
 def compare_json(test_instance, json, json_ans, verbose=False):
@@ -165,22 +170,22 @@ class CommonHeaderTest(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_two_import_with_embedded_preamble(self):
-        import common.a as a
-        import common.b as b
+        from .common import a
+        from .common import b
 
         m = b.struct_mystruct()
         b.bar(ctypes.byref(m))
         a.foo(ctypes.byref(m))
 
     def test_one_import(self):
-        import common.b as b
+        from .common import b
 
         m = b.struct_mystruct()
         b.bar(ctypes.byref(m))
 
     def test_two_import(self):
-        import common.a2 as a2
-        import common.b2 as b2
+        from .common import a2
+        from .common import b2
 
         m = b2.struct_mystruct()
         b2.bar(ctypes.byref(m))
@@ -2264,7 +2269,7 @@ class LongDoubleTest(unittest.TestCase):
 
 
 class MainTest(unittest.TestCase):
-    script = os.path.join(test_directory, os.pardir, os.pardir, "run.py")
+    script = os.path.join(TEST_DIR, os.pardir, "run.py")
 
     """Test primary entry point used for ctypesgen when called as executable:
     ctypesgen.main.main()

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skip_missing_interpreters = true
 deps =
     pytest
 commands =
-    pytest -v --showlocals ctypesgen/test/testsuite.py
+    pytest -v --showlocals tests/testsuite.py
     # pytest -v -v -k struct_json --showlocals ctypesgen/test/testsuite.py
 
 [testenv:black]


### PR DESCRIPTION
Move test directory to root directory, this includes:
- renaming the directory to "tests"
- making it a package with addition of `__init__.py`


Tests can be invoked from root directory by:

```py
python3 -m unittest
python3 -m unittest tests.testsuite
# python3 -m unittest tests.testsuite.[TestCase class].[test name]
python3 -m unittest tests.testsuite.StdBoolTest.test_stdbool_type
```

alternatively, using pytest:

```py
pytest -v --showlocals tests/testsuite.py
pytest -v --showlocals tests/testsuite.py::StdBoolTest::test_stdbool_type
```