### PR TITLE
Allow relative output path with no-embed-preamble

### DIFF
--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -144,7 +144,8 @@ class WrapperPrinter:
 
     def _copy_preamble_loader_files(self, path):
         if os.path.isfile(path):
-            dst = os.path.dirname(path)
+            abspath = os.path.abspath(path)
+            dst = os.path.dirname(abspath)
         else:
             error_message(
                 "Cannot copy preamble and loader files",


### PR DESCRIPTION
This fixes output failure with `--no-embed-preamble` when output file wasn't an absolute path, as reported with:
https://github.com/ctypesgen/ctypesgen/pull/117#issuecomment-955632963