### PR TITLE
Prepare for packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+## Change Log
+
+### Unreleased
+
+This release has a number of bug fixes in addition to a few new features.
+Following a complete transition to Python 3, with dropped Python 2 support,
+major work was made towards code modernization and quality.
+
+- The code is now Black formatted and Flake8 tested
+- Greatly improved unittest framework
+- Embedded PLY version updated to 3.11
+- New option: `--no-embed-preamble` create separate files for preamble and
+  loader instead of embedding in each output file
+- New option: `--allow-gnu-c` do not undefine `__GNUC__`
+- Fixed library loader search path on macOS
+- Fixed rare bug, processing (legacy) header files with MacRoman encoding
+  on macOS
+- Added full support for floating and integer constants
+- Added support for sized integer types on Windows
+- Added support to handle restrict keyword
+- Added name formats to posix library loader
+
+### v1.0.2
+
+Many issues fixed. Parse gcc attributes more
+
+Implements automatic calling convention selection based on gcc attributes for
+stdcall/cdecl.
+
+- Simplify and unify library loader for various platforms. Improve library path
+  searches on Linux (parsed ld.so.conf includes now).
+- First implementaion of #pragma pack
+- First implemenation of #undef
+- Adds several command line options:
+  `-D` `--define`
+  `-U` `--undefine`
+  `--no-undefs`
+  `-P` `--strip-prefix`
+  `--debug-level`
+
+### v1.0.1
+
+Fix handling of function prototypes 
+
+Other minor improvments included.
+
+### v1.0.0
+
+Py2/Py3 support 
+
+Various development branches merged back
+
+In addition to the various developments from the different branches, this
+tag also represents a code state that:
+
+- ties in with Travis CI to watch code developments
+- improves testsuite, including moving all JSON tests to testsuite
+- includes a decent Debian package build configuration
+- automatically creates a man page to be included in the Debian package

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2019, Ctypesgen Developers
+Copyright (c) 2007-2022, Ctypesgen Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft ctypesgen
 recursive-exclude ctypesgen .gitignore
+global-exclude *.py[cod]
 include ctypesgen/VERSION

--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ When outputting JSON, you will probably also want to use
 --no-python-types
 ```
 
-## License
-
-_ctypesgen_ is distributed under the New (2-clause) BSD License:
-http://www.opensource.org/licenses/bsd-license.php
-
 ## Related Software of Interest
 
 _libffi_ is a portable Foreign Function Interface library:
@@ -83,4 +78,7 @@ http://sources.redhat.com/libffi/
 _Mork_, the friendly alien, can be found at:
 https://github.com/rrthomas/mork
 
+## License
 
+_ctypesgen_ is distributed under the New (2-clause) BSD License:
+http://www.opensource.org/licenses/bsd-license.php

--- a/README.md
+++ b/README.md
@@ -1,102 +1,86 @@
                               ctypesgen
                               ---------
 
-                  (c) Ctypesgen developers 2007-2021
-                 https://github.com/davidjamesca/ctypesgen
+                  (c) Ctypesgen developers 2007-2022
+                 https://github.com/ctypesgen/ctypesgen
 
-ctypesgen is a pure-python ctypes wrapper generator. It can also
-output JSON, which can be used with Mork, which generates bindings for
-Lua, using the alien module (which binds libffi to Lua).
+_ctypesgen_ is a pure-python ctypes wrapper generator. It parses C header files
+and creates a wrapper for libraries based on what it finds.
 
-Documentation
--------------
+Preprocessor macros are handled in a manner consistent with typical C code.
+Preprocessor macro functions are translated into Python functions that are then
+made available to the user of the newly-generated Python wrapper library.
 
-See https://github.com/davidjamesca/ctypesgen/wiki for full documentation.
+It can also output JSON, which can be used with Mork, which generates bindings
+for Lua, using the alien module (which binds libffi to Lua).
 
-Basic Usage
------------
+## Documentation
+
+See https://github.com/ctypesgen/ctypesgen/wiki for full documentation.
+
+Run `ctypesgen --help` for full range of available options.
+
+## Installation
+
+_ctypesgen_ can be installed by `pip install ctypesgen`. It requires Python 3.7
+to run.
+
+## Basic Usage
 
 This project automatically generates ctypes wrappers for header files written
 in C.
 
 For example, if you'd like to generate Neon bindings, you can do so using this
-recipe:
+recipe (using a standard pip install):
 
-	$ python ctypesgen.py -lneon /usr/local/include/neon/ne_*.h -o neon.py
+```sh
+ctypesgen -lneon /usr/local/include/neon/ne_*.h -o neon.py
+```
 
 Some libraries, such as APR, need special flags to compile. You can pass these
 flags in on the command line.
 
 For example:
 
-	$ FLAGS = `apr-1-config --cppflags --includes`
-	$ python ctypesgen.py $FLAGS -llibapr-1.so $HOME/include/apr-1/apr*.h -o apr.py
+```sh
+FLAGS = `apr-1-config --cppflags --includes`
+ctypesgen $FLAGS -llibapr-1.so $HOME/include/apr-1/apr*.h -o apr.py
+```
 
 Sometimes, libraries will depend on each other. You can specify these
 dependencies using -mmodule, where module is the name of the dependency module.
 
 Here's an example for apr_util:
 
-	$ python ctypesgen.py $FLAGS -llibaprutil-1.so $HOME/include/apr-1/ap[ru]*.h \
+```sh
+ctypesgen $FLAGS -llibaprutil-1.so $HOME/include/apr-1/ap[ru]*.h \
 	-mapr -o apr_util.py
-
+```
 
 If you want JSON output (e.g. for generating Lua bindings), use
 
-	--output-language=json
+```
+--output-language=json
+```
 
 When outputting JSON, you will probably also want to use
 
-	--all-headers --builtin-symbols --no-stddef-types --no-gnu-types
-	--no-python-types
+```
+--all-headers --builtin-symbols --no-stddef-types --no-gnu-types
+--no-python-types
+```
 
-License
--------
+## License
 
-ctypesgen is distributed under the New (2-clause) BSD License:
+_ctypesgen_ is distributed under the New (2-clause) BSD License:
 http://www.opensource.org/licenses/bsd-license.php
 
-libffi is a portable Foreign Function Interface library:
+## Related Software of Interest
+
+_libffi_ is a portable Foreign Function Interface library:
 http://sources.redhat.com/libffi/
 
-Mork, the friendly alien, can be found at:
+_Mork_, the friendly alien, can be found at:
 https://github.com/rrthomas/mork
 
 
-Versioning
-----------
-
-Versioning within ctypesgen follows these general rules:
-
-* Versions are all defined with specific reference to a commit that is relative
-  to a Git tag.
-* Versions numbers include enough information to find the exact commit that
-  represents the version release.
-* All tags should follow the format of:  ctypesgen-x.y.z
-    * x : Major revision with major differences of capabilities as compared to
-          other major revisions.  The definition of "major capabilities" is a
-          somewhat subjective concept, dependent on the developers.
-    * y : Minor revision with incompatible differences of interfaces as compared
-          to earlier revisions.  Interfaces that are considered to impact the
-          minor revision number are external interfaces such as the command line
-          or perhaps python version support.
-    * z : Micro revision indicating a general acceptance of multiple patches
-          since last tag. This number may be used to help mark minor development
-          milestones.
-
-By using the Git command ‘git describe‘, a unique identifier of the full version
-string can be shown as:
-
-  * ctypesgen-x.y.z[-n-g*sha1*]
-    where [-n-g*sha1*] shows up *automatically* if changes have been made since
-    the last tag
-  * n : Indicates the number of commits since the last tag
-  * g*sha1*: Indicates the abreviated SHA1 hash of the latest commit
-
-Thus, the version *1.0.0-2* means that the last tag before that version was
-*ctypesgen-1.0.0* and the version *1.0.0-2* is exactly 2 commits after the tag
-*ctypesgen-1.0.0*.
-
-To re-baseline the [-n-g*sha1*] portion showing up in "git describe" (i.e.
-remove it until another commit is added), we simply add another tag following
-the *ctypesgen-x.y.z* format.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,36 @@
+## Versioning
+
+Versioning within ctypesgen follows these general rules:
+
+* Versions are all defined with specific reference to a commit that is relative
+  to a Git tag.
+* Versions numbers include enough information to find the exact commit that
+  represents the version release.
+* All tags should follow the format of:  ctypesgen-x.y.z
+    * x : Major revision with major differences of capabilities as compared to
+          other major revisions.  The definition of "major capabilities" is a
+          somewhat subjective concept, dependent on the developers.
+    * y : Minor revision with incompatible differences of interfaces as compared
+          to earlier revisions.  Interfaces that are considered to impact the
+          minor revision number are external interfaces such as the command line
+          or perhaps python version support.
+    * z : Micro revision indicating a general acceptance of multiple patches
+          since last tag. This number may be used to help mark minor development
+          milestones.
+
+By using the Git command ‘git describe‘, a unique identifier of the full version
+string can be shown as:
+
+  * ctypesgen-x.y.z[-n-g*sha1*]
+    where [-n-g*sha1*] shows up *automatically* if changes have been made since
+    the last tag
+  * n : Indicates the number of commits since the last tag
+  * g*sha1*: Indicates the abreviated SHA1 hash of the latest commit
+
+Thus, the version *1.0.0-2* means that the last tag before that version was
+*ctypesgen-1.0.0* and the version *1.0.0-2* is exactly 2 commits after the tag
+*ctypesgen-1.0.0*.
+
+To re-baseline the [-n-g*sha1*] portion showing up in "git describe" (i.e.
+remove it until another commit is added), we simply add another tag following
+the *ctypesgen-x.y.z* format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools>=44", "wheel", "setuptools_scm[toml]>=3.4.3"]
+requires = [
+    "setuptools>=44",
+    "wheel",
+    "setuptools_scm[toml]>=3.4.3"
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = ctypesgen
 license = BSD-2-Clause
 description = Python wrapper generator for ctypes
 url = https://github.com/ctypesgen/ctypesgen
-long_description = file: README.md
+long_description = file: README.md, LICENSE, CHANGELOG.md
 long_description_content_type = text/markdown
 classifiers =
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,25 +2,31 @@
 name = ctypesgen
 license = BSD-2-Clause
 description = Python wrapper generator for ctypes
-url = https://github.com/davidjamesca/ctypesgen
-long_description = ctypesgen reads parses c header files and creates a wrapper for libraries based on what it finds.  Preprocessor macros are handled in a manner consistent with typical c code.  Preprocessor macro functions are translated into Python functions that are then made available to the user of the newly-generated Python wrapper library.
-    ctypesgen can also output JSON, which can be used with Mork, which generates bindings for Lua, using the alien module (which binds libffi to Lua).
-long_description_content_type = text/plain
+url = https://github.com/ctypesgen/ctypesgen
+long_description = file: README.md
+long_description_content_type = text/markdown
 classifiers =
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
     Development Status :: 4 - Beta
     Operating System :: OS Independent
     Intended Audience :: Developers
     Topic :: Software Development :: Code Generators
     Topic :: Software Development :: Pre-processors
     Topic :: Software Development :: Build Tools
+    Environment :: Console
 
 [options]
-packages = find:
+packages = ctypesgen
+package_dir =
 include_package_data = True
 setup_requires = setuptools>=44; wheel; toml; setuptools_scm>=3.4.3
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts = ctypesgen = ctypesgen.main:main


### PR DESCRIPTION
This updates the project for packaging to pypi.org, I have tested it against https://test.pypi.org.
So in practice, after merge, it should be enough to add a version tag and upload.

_ctypesgen_ package description is now taken from README.md, which I modified for this aims. Please see if any modifications are needed to that file.

Addresses #129 
