### PR TITLE
Add workflow trigger on fork operation

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,7 +3,6 @@ name: Python Flake8 Code Quality
 on:
   - push
   - pull_request
-  - branch
   - fork
 
 jobs:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -3,6 +3,8 @@ name: Python Flake8 Code Quality
 on:
   - push
   - pull_request
+  - branch
+  - fork
 
 jobs:
   flake8:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   - push
   - pull_request
+  - branch
+  - fork
 
 jobs:
   setup-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 on:
   - push
   - pull_request
-  - branch
   - fork
 
 jobs:


### PR DESCRIPTION
After I fork the repository, the workflows were not run. To execute the workflows, changes had to be pushed first.
Especially after a fork it would be nice to see the checks running through with the initial code, before I modify anything. This way I can quickly see if they were already broken or if I introduced the error.
This goal is achieved by adding additional triggers to the workflow files. Existing build triggers are not affected, and no other issues are known.
