### PR TITLE
Update CI Black version to 22.3.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 [testenv:black]
 deps =
     six
-    black==21.7b0
+    black==22.3.0
 basepython = python3.7
 commands =
     black --check --diff setup.py run.py ctypesgen/ --exclude='.*tab.py|ctypesgen/parser/cgrammar.py|ctypesgen/parser/lex.py|ctypesgen/parser/yacc.py'


### PR DESCRIPTION
Click 8.1.0 breaks pre 22.3.0 versions of Black.

(https://github.com/psf/black/issues/2964)