### PR TITLE
Add GH action to publish on PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,28 @@
+name: Publish Python distributions to PyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to PyPI
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+        - name: Check out repository
+          uses: actions/checkout@master
+
+        - name: Set up Python 3.10
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.10"
+
+        - name: Install pypa/build
+          run: python -m pip install build --user
+
+        - name: Build a binary wheel and a source tarball
+          run: python -m build --sdist --wheel --outdir dist/ .
+
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Change Log
 
-### Unreleased
+### v1.1.0
 
 This release has a number of bug fixes in addition to a few new features.
 Following a complete transition to Python 3, with dropped Python 2 support,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ major work was made towards code modernization and quality.
 - Added support to handle `restrict` and `_Noreturn` keywords
 - Added name formats to posix library loader
 - Fixed mapping of 'short int' to c_short
+- Git tags are now using `x.y.z` format
 
 ### v1.0.2
 

--- a/ctypesgen/version.py
+++ b/ctypesgen/version.py
@@ -37,13 +37,14 @@ def version():
         out, err = p.communicate()
         if p.returncode:
             raise RuntimeError("no version defined?")
-        return out.strip().decode()
+        git_tag = out.strip().decode()
+        return f"{DEFAULT_PREFIX}-{git_tag}"
     except Exception:
         # failover is to try VERSION_FILE instead
         try:
             return read_file_version()
         except Exception:
-            return DEFAULT_PREFIX + "-0.0.0"
+            return f"{DEFAULT_PREFIX}-0.0.0"
 
 
 def version_number():
@@ -72,11 +73,11 @@ if __name__ == "__main__":
     import argparse
 
     p = argparse.ArgumentParser()
-    p.add_argument("--save", action="store_true", help="Store version to " + VERSION_FILE)
+    p.add_argument("--save", action="store_true", help=f"Store version to {VERSION_FILE}")
     p.add_argument(
         "--read-file-version",
         action="store_true",
-        help="Read the version stored in " + VERSION_FILE,
+        help=f"Read the version stored in {VERSION_FILE}",
     )
     args = p.parse_args()
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -6,7 +6,7 @@ Versioning within ctypesgen follows these general rules:
   to a Git tag.
 * Versions numbers include enough information to find the exact commit that
   represents the version release.
-* All tags should follow the format of:  ctypesgen-x.y.z
+* All tags should follow the format of:  x.y.z
     * x : Major revision with major differences of capabilities as compared to
           other major revisions.  The definition of "major capabilities" is a
           somewhat subjective concept, dependent on the developers.
@@ -21,16 +21,15 @@ Versioning within ctypesgen follows these general rules:
 By using the Git command ‘git describe‘, a unique identifier of the full version
 string can be shown as:
 
-  * ctypesgen-x.y.z[-n-g*sha1*]
+  * x.y.z[-n-g*sha1*]
     where [-n-g*sha1*] shows up *automatically* if changes have been made since
     the last tag
   * n : Indicates the number of commits since the last tag
   * g*sha1*: Indicates the abreviated SHA1 hash of the latest commit
 
 Thus, the version *1.0.0-2* means that the last tag before that version was
-*ctypesgen-1.0.0* and the version *1.0.0-2* is exactly 2 commits after the tag
-*ctypesgen-1.0.0*.
+*1.0.0* and the version *1.0.0-2* is exactly 2 commits after the tag *1.0.0*.
 
 To re-baseline the [-n-g*sha1*] portion showing up in "git describe" (i.e.
 remove it until another commit is added), we simply add another tag following
-the *ctypesgen-x.y.z* format.
+the *x.y.z* format.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,15 @@ classifiers =
     Environment :: Console
 
 [options]
-packages = ctypesgen
+packages = find:
 package_dir =
 include_package_data = True
 setup_requires = setuptools>=44; wheel; toml; setuptools_scm>=3.4.3
 python_requires = >=3.7
+
+[options.packages.find]
+exclude =
+    tests*
 
 [options.entry_points]
 console_scripts = ctypesgen = ctypesgen.main:main


### PR DESCRIPTION
This adds a Github action to publish automatically:
- to https://test.pypi.org on each push
- to official repo of https://pypi.org upon GH release (version is based on tag)

This also implements handling of simpler tag formats like 'x.x.x' instead of present 'ctypesgen-x.x.x'.

For this to work:
@Alan-R  Could you create an API token on https://test.pypi.org/project/ctypesgen/ and set up here as a secret  named `TEST_PYPI_API_TOKEN` ([see here how](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github)).

I took the liberty to bump the version to `1.1.0`.