### PR TITLE
Publish to PyPI on GH release event

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,15 +1,17 @@
 name: Publish Python distributions to PyPI
 
-on: push
-
+on:
+  release:
+    types: [published]
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
-    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
         - name: Check out repository
-          uses: actions/checkout@master
+          uses: actions/checkout@v3
+          with:
+            ref:  ${{ github.ref }}
 
         - name: Set up Python 3.10
           uses: actions/setup-python@v3


### PR DESCRIPTION
This will enable publishing to PyPI based on an existing (and annotated) tag, which also will be picked up by `git describe`.
