### PR TITLE
Add built wheel and source packages to GH release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,12 @@ jobs:
         - name: Build a binary wheel and a source tarball
           run: python -m build --sdist --wheel --outdir dist/ .
 
+        - name: Publish distribution to GitHub
+          uses: softprops/action-gh-release@v1
+          with:
+            files: |
+              dist/*
+
         - name: Publish distribution to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
           with:

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,3 +1,5 @@
+# How to Publish a New Release
+
 ## Versioning
 
 Versioning within ctypesgen follows these general rules:
@@ -18,7 +20,7 @@ Versioning within ctypesgen follows these general rules:
           since last tag. This number may be used to help mark minor development
           milestones.
 
-By using the Git command ‘git describe‘, a unique identifier of the full version
+By using the Git command `git describe`, a unique identifier of the full version
 string can be shown as:
 
   * x.y.z[-n-g*sha1*]
@@ -30,6 +32,38 @@ string can be shown as:
 Thus, the version *1.0.0-2* means that the last tag before that version was
 *1.0.0* and the version *1.0.0-2* is exactly 2 commits after the tag *1.0.0*.
 
-To re-baseline the [-n-g*sha1*] portion showing up in "git describe" (i.e.
+To re-baseline the [-n-g*sha1*] portion showing up in `git describe` (i.e.
 remove it until another commit is added), we simply add another tag following
 the *x.y.z* format.
+
+:exclamation: The version set for release should comply with
+[PEP 440](https://peps.python.org/pep-0440/).
+
+## Last changes on repo
+
+```bash
+# Update content and set version of latest changes in CHANGELOG.md
+vim CHANGELOG.md
+...
+git commit -a -S
+
+version="2.2.5"
+commit=$(git rev-parse HEAD)
+tag_message="ctypesgen v${version}"
+git tag -a -m "$tag_message" $version $commit
+
+git push -u --tags <repo> <branch>
+```
+
+## Publish on GitHub
+
+- Go to <https://github.com/ctypesgen/ctypesgen/releases/new>.
+- Choose the newly created tag and fill in title (preferable in the format of
+  'ctypesgen v.X.Y.Z') and description (if appropriate, use the content for this
+  version listed in CHANGELOG.md).
+- Publish.
+
+## Post-release
+
+After the release, a new headline `### Unreleased` should be added at the top
+of the file `CHANGELOG.md`.


### PR DESCRIPTION
This adds the same built wheel and source packages destined to PyPI also to the GitHub release.

In addition, publishing instructions are added for convenience.