### PR TITLE
CLI: Add option to skip load_library

### DIFF
--- a/ctypesgen/main.py
+++ b/ctypesgen/main.py
@@ -280,6 +280,14 @@ def main(givenargs=None):
         default=False,
         help="Do not support extra C types built in to Python",
     )
+    op.add_option(
+        "",
+        "--no-load-library",
+        action="store_true",
+        dest="no_load_library",
+        default=False,
+        help="Do not try to load library during the processing"
+    )
 
     # Printer options
     op.add_option(

--- a/ctypesgen/options.py
+++ b/ctypesgen/options.py
@@ -41,6 +41,7 @@ default_values = {
     "debug_level": 0,
     "strip_prefixes": [],
     "embed_preamble": True,
+    "no_load_library": False
 }
 
 

--- a/ctypesgen/processor/operations.py
+++ b/ctypesgen/processor/operations.py
@@ -14,7 +14,7 @@ from ctypesgen.descriptions import (
     StructDescription,
     TypedefDescription,
 )
-from ctypesgen.messages import warning_message
+from ctypesgen.messages import warning_message, status_message
 
 
 # Processor functions
@@ -264,6 +264,10 @@ def find_source_libraries(data, opts):
     libraryloader.add_library_search_dirs(opts.compile_libdirs)
 
     for library_name in opts.libraries:
+        if opts.no_load_library:
+            status_message("Bypass load_library %s" % library_name)
+            continue
+
         try:
             library = libraryloader.load_library(library_name)
         except ImportError:


### PR DESCRIPTION
This PR add a CLI option to bypass the load_library because in some very specific cases it can just stop processing.

My case is that I have a library that is build with `-fsanitize=address` (which analyze memory leaks). It requires to have a environment variable LD_PRELOAD pointing to libasan.so library. But if we do that, it will also analyze the memory leaks of Python and return an error code.
If this environment variable is not specified, it will just stop & exit the program after it tried to load.

And finally in some cases (like cross compile), you may know that you won't be able to load the libray, this flag can be use to not have the warning "Could not load library...".