### PR TITLE
Support for C++ bool

### DIFF
--- a/ctypesgen/__main__.py
+++ b/ctypesgen/__main__.py
@@ -12,6 +12,7 @@ from ctypesgen import (
     printer_json,
     processor,
     version,
+    ctypedescs
 )
 
 
@@ -323,9 +324,18 @@ def main(givenargs=None):
         type=int,
         help="Run ctypesgen with specified debug level (also applies to yacc parser)",
     )
+    parser.add_argument(
+        "--include-stdbool",
+        dest="include_stdbool",
+        action="store_true",
+        help="Adds support for `bool` from stdbool.h",
+    )
 
     parser.set_defaults(**core_options.default_values)
     args = parser.parse_args(givenargs)
+
+    if args.include_stdbool:
+        ctypedescs.ctypes_type_map[("bool", True, 0)] = "c_bool"
 
     args.compile_libdirs += args.universal_libdirs
     args.runtime_libdirs += args.universal_libdirs

--- a/ctypesgen/ctypedescs.py
+++ b/ctypesgen/ctypedescs.py
@@ -58,6 +58,7 @@ ctypes_type_map = {
     ("__uint64", False, 0): "c_uint64",
     ("__uint64_t", False, 0): "c_uint64",
     ("_Bool", True, 0): "c_bool",
+    ("bool", True, 0): "c_bool",
 }
 
 ctypes_type_map_python_builtin = {

--- a/ctypesgen/ctypedescs.py
+++ b/ctypesgen/ctypedescs.py
@@ -58,7 +58,6 @@ ctypes_type_map = {
     ("__uint64", False, 0): "c_uint64",
     ("__uint64_t", False, 0): "c_uint64",
     ("_Bool", True, 0): "c_bool",
-    ("bool", True, 0): "c_bool",
 }
 
 ctypes_type_map_python_builtin = {


### PR DESCRIPTION
This should fix #173 and potentially #133 by adding `bool` to the symbol table.
It is a bit of a hack since `bool` is not a C keyword which might lead to conflicts with existing C code that defines `bool` otherwise. However, `typedef _Bool bool;` is the intended use of C's `_Bool` type as implied by the `stdbool.h` header. If adding `bool` directly is not acceptable due to backward compatibility, I would propose adding a command line option to add `bool`. Even better, one could define `bool` only if it is missing / not defined in the provided headers.