### PR TITLE
Type annotations for structs

### DIFF
--- a/ctypesgen/printer_python/defaultheader.py
+++ b/ctypesgen/printer_python/defaultheader.py
@@ -6,4 +6,6 @@ Generated with:
 Do not modify this file.
 """
 
+from __future__ import annotations
+
 __docformat__ = "restructuredtext"

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -1,6 +1,15 @@
+from typing import TypeVar, Type, get_type_hints
 import ctypes
 import sys
 from ctypes import *  # noqa: F401, F403
+
+T = TypeVar("T")
+
+def struct_decorator(cls: Type[T]) -> Type[T]:
+    class Internal(cls.__base__):
+        __annotations__ = cls.__annotations__
+        __slots__ = list(cls.__annotations__.keys())
+    return Internal
 
 _int_types = (ctypes.c_int16, ctypes.c_int32)
 if hasattr(ctypes, "c_int64"):


### PR DESCRIPTION
Added type annotations for structs using a minimalistic wrapper that resolves forward references using `__future__.annotations`. Also, the code for handling anonymous fields was moved to the struct "declaration" part to generate the annotations.