### PR TITLE
Fix function macros with empty params list

### DIFF
--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -418,10 +418,11 @@ class WrapperPrinter:
             )
 
     def print_macro(self, macro):
-        if macro.params:
-            self.print_func_macro(macro)
-        else:
+        # important: must check precisely against None because params may be an empty list for a func macro
+        if macro.params is None:
             self.print_simple_macro(macro)
+        else:
+            self.print_func_macro(macro)
 
     def print_simple_macro(self, macro):
         # The macro translator makes heroic efforts but it occasionally fails.

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -418,7 +418,8 @@ class WrapperPrinter:
             )
 
     def print_macro(self, macro):
-        # important: must check precisely against None because params may be an empty list for a func macro
+        # important: must check precisely against None because params may be
+        # an empty list for a func macro
         if macro.params is None:
             self.print_simple_macro(macro)
         else:


### PR DESCRIPTION
This fixes a bug in compiling function macros without params that was present in ctypesgen since at least 2008 according to git blame.

Previously, e.g. the following macro from pymacro.h
```c
#  define Py_UNREACHABLE() \
    Py_FatalError("Unreachable C code path reached")
```
would translate to
```python
Py_UNREACHABLE = Py_FatalError("Unreachable C code path reached")
```
which (without try/except guards) promptly raises an exception when importing the module, rendering the macro unusable.
i.e. macros without params were not translated to a function, but the action was called once on import time, and the symbol name merely got assigned the return value of that call.

With this patch, it now correctly translates to
```python
def Py_UNREACHABLE():
    return Py_FatalError('Unreachable C code path reached')
```

-----

This was discovered during development of the pypdfium2-team fork, thanks to a new option to disable macro guards.
I thought I'd also submit it here because it's a very simple, standalone fix.