### PR TITLE
[Backport] Fix presumed `no` vs `never` typo

### DIFF
--- a/ctypesgen/processor/pipeline.py
+++ b/ctypesgen/processor/pipeline.py
@@ -81,13 +81,15 @@ def calculate_final_inclusion(data, opts):
 
     def can_include_desc(desc):
         if desc.can_include is None:
-            if desc.include_rule == "no":
+            if desc.include_rule == "never":
                 desc.can_include = False
             elif desc.include_rule == "yes" or desc.include_rule == "if_needed":
                 desc.can_include = True
                 for req in desc.requirements:
                     if not can_include_desc(req):
                         desc.can_include = False
+            else:
+                assert False, f"unknown include rule '{desc.include_rule}'"
         return desc.can_include
 
     def do_include_desc(desc):


### PR DESCRIPTION
Searching the whole codebase for "no" and 'no' yields nothing, so supposedly this was a typo and the writer actually meant `never`. Also note the docstring above, which does not mention `no`, only `never`.

According to git blame, this was present ever since the ctypesgen is on GH.