### PR TITLE
Fix conflicting names resolver being never called

### DIFF
--- a/ctypesgen/processor/pipeline.py
+++ b/ctypesgen/processor/pipeline.py
@@ -60,7 +60,7 @@ def process(data, options):
     filter_by_regexes_exclude(data, options)
     filter_by_regexes_include(data, options)
     remove_macros(data, options)
-    if options.output_language == "python":
+    if options.output_language.startswith("py"):
         # this function is python specific
         fix_conflicting_names(data, options)
     find_source_libraries(data, options)


### PR DESCRIPTION
This fixes #145

The function was never actually called due to a misaligned if check introduced in commit f12737e5bb1e6075023ef165b63e7bdb46581ef7

Picked from pypdfium2-team fork commit https://github.com/pypdfium2-team/ctypesgen/commit/105a3c6cd574841da223c16d94d84807f67279a5