### PR TITLE
Use Python 3.3's `yield from` when appropriate

### DIFF
--- a/ctypesgen/libraryloader.py
+++ b/ctypesgen/libraryloader.py
@@ -135,8 +135,7 @@ class LibraryLoader:
                     yield path
 
             # then we search all paths identified as platform-specific lib paths
-            for path in self.getplatformpaths(libname):
-                yield path
+            yield from self.getplatformpaths(libname)
 
             # Finally, we'll try the users current working directory
             for fmt in self.name_formats:
@@ -357,11 +356,10 @@ class PosixLibraryLoader(LibraryLoader):
             self._create_ld_so_cache()
 
         result = self._ld_so_cache.get(libname, set())
-        for i in result:
-            # we iterate through all found paths for library, since we may have
-            # actually found multiple architectures or other library types that
-            # may not load
-            yield i
+        # we iterate through all found paths for library, since we may have
+        # actually found multiple architectures or other library types that
+        # may not load
+        yield from result
 
 
 # Windows

--- a/demo/pydemolib.py
+++ b/demo/pydemolib.py
@@ -581,8 +581,7 @@ class LibraryLoader:
                     yield path
 
             # then we search all paths identified as platform-specific lib paths
-            for path in self.getplatformpaths(libname):
-                yield path
+            yield from self.getplatformpaths(libname):
 
             # Finally, we'll try the users current working directory
             for fmt in self.name_formats:
@@ -803,11 +802,10 @@ class PosixLibraryLoader(LibraryLoader):
             self._create_ld_so_cache()
 
         result = self._ld_so_cache.get(libname, set())
-        for i in result:
-            # we iterate through all found paths for library, since we may have
-            # actually found multiple architectures or other library types that
-            # may not load
-            yield i
+        # we iterate through all found paths for library, since we may have
+        # actually found multiple architectures or other library types that
+        # may not load
+        yield from result
 
 
 # Windows


### PR DESCRIPTION
This change is a small one, but was made here since it was extracted from our downstream's copy in https://github.com/OSGeo/grass/pull/3316.

Basically, yield in simple for loops can be used with `yield from` since Python 3.3.
A clear explanation can be found here https://docs.astral.sh/ruff/rules/yield-in-for-loop/