### PR TITLE
[Backport] Fix syntax errors on defines using `__attribute__ ((...))`

### DIFF
--- a/ctypesgen/parser/cgrammar.py
+++ b/ctypesgen/parser/cgrammar.py
@@ -1277,6 +1277,7 @@ def p_define(p):
     """ define : PP_DEFINE PP_DEFINE_NAME PP_END_DEFINE
                | PP_DEFINE PP_DEFINE_NAME type_name PP_END_DEFINE
                | PP_DEFINE PP_DEFINE_NAME constant_expression PP_END_DEFINE
+               | PP_DEFINE PP_DEFINE_NAME gcc_attribute PP_END_DEFINE
                | PP_DEFINE PP_DEFINE_MACRO_NAME LPAREN RPAREN PP_END_DEFINE
                | PP_DEFINE PP_DEFINE_MACRO_NAME LPAREN RPAREN constant_expression PP_END_DEFINE
                | PP_DEFINE PP_DEFINE_MACRO_NAME LPAREN macro_parameter_list RPAREN PP_END_DEFINE
@@ -1303,9 +1304,6 @@ def p_define(p):
                 expr = None
             elif len(p) == 8:
                 expr = p[6]
-
-        filename = p.slice[1].filename
-        lineno = p.slice[1].lineno
 
         p.parser.cparser.handle_define_macro(p[2], params, expr, filename, lineno)
 

--- a/ctypesgen/parser/datacollectingparser.py
+++ b/ctypesgen/parser/datacollectingparser.py
@@ -23,6 +23,7 @@ from ctypesgen.descriptions import (
 from ctypesgen.expressions import ConstantExpressionNode
 from ctypesgen.messages import error_message, status_message
 from ctypesgen.parser import ctypesparser
+from ctypesgen.parser.cdeclarations import Attrib
 
 
 class DataCollectingParser(ctypesparser.CtypesParser, CtypesTypeVisitor):
@@ -279,6 +280,9 @@ class DataCollectingParser(ctypesparser.CtypesParser, CtypesTypeVisitor):
             constant = ConstantDescription(name, expr, src)
             self.constants.append(constant)
             self.all.append(constant)
+            return
+
+        if type(expr) is Attrib:
             return
 
         expr.visit(self)


### PR DESCRIPTION
This fixes syntax errors when parsing `/usr/include/sys/cdefs.h`

Closes #181
Backport of https://github.com/pypdfium2-team/ctypesgen/commit/4d318bdf8c5861f8921a067c68f652ca89078bd9, https://github.com/pypdfium2-team/ctypesgen/commit/08f0433499f454f2bfc84b660dc2cc72e30907ef
