### PR TITLE
Rework of struct definition

### DIFF
--- a/ctypesgen/printer_python/defaultheader.py
+++ b/ctypesgen/printer_python/defaultheader.py
@@ -6,4 +6,6 @@ Generated with:
 Do not modify this file.
 """
 
+from __future__ import annotations
+
 __docformat__ = "restructuredtext"

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -7,6 +7,7 @@ T = TypeVar("T")
 
 def struct_decorator(cls: Type[T]) -> Type[T]:
     class Internal(cls.__base__):
+        __qualname__ = cls.__qualname__
         __annotations__ = cls.__annotations__
         __slots__ = list(cls.__annotations__.keys())
     return Internal

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -1,16 +1,6 @@
-from typing import TypeVar, Type, get_type_hints
 import ctypes
 import sys
 from ctypes import *  # noqa: F401, F403
-
-T = TypeVar("T")
-
-def struct_decorator(cls: Type[T]) -> Type[T]:
-    class Internal(cls.__base__):
-        __qualname__ = cls.__qualname__
-        __annotations__ = cls.__annotations__
-        __slots__ = list(cls.__annotations__.keys())
-    return Internal
 
 _int_types = (ctypes.c_int16, ctypes.c_int32)
 if hasattr(ctypes, "c_int64"):

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -3,6 +3,7 @@ import sys
 from ctypes import *  # noqa: F401, F403
 from typing import get_type_hints
 
+
 def finalize_struct(cls):
     fields = []
     for name, ctype in get_type_hints(cls).items():
@@ -12,6 +13,7 @@ def finalize_struct(cls):
         fields.append(tuple(entry))
     cls._fields_ = fields
     del cls._tmp_bitfields_
+
 
 _int_types = (ctypes.c_int16, ctypes.c_int32)
 if hasattr(ctypes, "c_int64"):

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -8,7 +8,7 @@ def finalize_struct(cls):
     for name, ctype in get_type_hints(cls).items():
         entry = [name, ctype]
         if name in cls._tmp_bitfields_:
-            entry.extend(cls._bitfields_[name])
+            entry.append(cls._tmp_bitfields_[name])
         cls._fields_.append(tuple(entry))
     del cls._tmp_bitfields_
 

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -1,11 +1,11 @@
 import ctypes
 import sys
 from ctypes import *  # noqa: F401, F403
-from inspect import get_annotations
+from typing import get_type_hints
 
 def finalize_struct(cls):
     cls._fields_ = []
-    for name, ctype in get_annotations(cls):
+    for name, ctype in get_type_hints(cls).items():
         entry = [name, ctype]
         if name in cls._bitfields_:
             entry.extend(cls._bitfields_[name])

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -1,6 +1,15 @@
+from typing import TypeVar, Type, get_type_hints
 import ctypes
 import sys
 from ctypes import *  # noqa: F401, F403
+
+T = TypeVar("T")
+
+def struct_decorator(cls: Type[T]) -> Type[T]:
+    class Internal(cls.__base__):
+        __annotations__ = cls.__annotations__
+        __slots__ = list(cls.__annotations__.keys())
+    return Internal
 
 _int_types = (ctypes.c_int16, ctypes.c_int32)
 if hasattr(ctypes, "c_int64"):

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -4,12 +4,13 @@ from ctypes import *  # noqa: F401, F403
 from typing import get_type_hints
 
 def finalize_struct(cls):
-    cls._fields_ = []
+    fields = []
     for name, ctype in get_type_hints(cls).items():
         entry = [name, ctype]
         if name in cls._tmp_bitfields_:
             entry.append(cls._tmp_bitfields_[name])
-        cls._fields_.append(tuple(entry))
+        fields.append(tuple(entry))
+    cls._fields_ = fields
     del cls._tmp_bitfields_
 
 _int_types = (ctypes.c_int16, ctypes.c_int32)

--- a/ctypesgen/printer_python/preamble.py
+++ b/ctypesgen/printer_python/preamble.py
@@ -7,7 +7,7 @@ def finalize_struct(cls):
     cls._fields_ = []
     for name, ctype in get_type_hints(cls).items():
         entry = [name, ctype]
-        if name in cls._bitfields_:
+        if name in cls._tmp_bitfields_:
             entry.extend(cls._bitfields_[name])
         cls._fields_.append(tuple(entry))
     del cls._tmp_bitfields_

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -259,7 +259,7 @@ class WrapperPrinter:
 
             self.file.write(f"\n")
             self.file.write(f"    __slots__ = list(__annotations__.keys())\n")
-            
+
             # TODO: maybe not implement this using a static member to avoid user confusion?
             self.file.write("\n")
             bitfields = list(filter(lambda x: isinstance(x[1], CtypesBitfield), struct.members))

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -229,8 +229,6 @@ class WrapperPrinter:
     def print_struct(self, struct):
         self.srcinfo(struct.src)
         base = {"union": "Union", "struct": "Structure"}[struct.variety]
-        if not struct.opaque:
-            self.file.write("@struct_decorator\n")
         self.file.write("class %s_%s(%s):\n" % (struct.variety, struct.tag, base))
         if struct.opaque:
             self.file.write("    pass\n")
@@ -258,6 +256,9 @@ class WrapperPrinter:
             # print annotations
             for name, ctype in struct.members:
                 self.file.write(f"    {name} : {ctype.py_string()}\n")
+
+            self.file.write(f"\n")
+            self.file.write(f"    __slots__ = list(__annotations__.keys())\n")
 
     def print_struct_members(self, struct):
         if struct.opaque:

--- a/ctypesgen/printer_python/printer.py
+++ b/ctypesgen/printer_python/printer.py
@@ -260,7 +260,7 @@ class WrapperPrinter:
             self.file.write(f"\n")
             self.file.write(f"    __slots__ = list(__annotations__.keys())\n")
             
-            # TODO: maybe not write implement this using a static member to avoid user confusion?
+            # TODO: maybe not implement this using a static member to avoid user confusion?
             self.file.write("\n")
             bitfields = list(filter(lambda x: isinstance(x[1], CtypesBitfield), struct.members))
             if len(bitfields) == 0:
@@ -268,7 +268,7 @@ class WrapperPrinter:
             else:
                 self.file.write(f"    _tmp_bitfields_ = dict(\n")
                 for name, ctype in bitfields:
-                    self.file.write(f"        {name} = {ctype.bitfield},\n")
+                    self.file.write(f"        {name} = {ctype.bitfield.py_string(False)},\n")
                 self.file.write("    )\n")
 
     def print_struct_members(self, struct):


### PR DESCRIPTION
This PR is a rework of how structs are defined and is an improvement in three points:
- correct `__slots__` (addressing https://github.com/ctypesgen/ctypesgen/issues/183)
- type annotations 
- less clutter / repetitive

This PR supersedes / is based on https://github.com/ctypesgen/ctypesgen/pull/185, which already contains some discussion of the changes introduced in this PR. It should mitigate the concerns raised by @mara004 related to https://github.com/ctypesgen/ctypesgen/pull/185 but has a slightly larger change set.