### PR TITLE
[Backport] ctypedescs: remove spurious APR types from type map

### DIFF
--- a/ctypesgen/ctypedescs.py
+++ b/ctypesgen/ctypedescs.py
@@ -66,9 +66,7 @@ ctypes_type_map_python_builtin = {
     ("int", True, 2): "c_longlong",
     ("int", False, 2): "c_ulonglong",
     ("size_t", True, 0): "c_size_t",
-    ("apr_int64_t", True, 0): "c_int64",
     ("off64_t", True, 0): "c_int64",
-    ("apr_uint64_t", False, 0): "c_uint64",
     ("wchar_t", True, 0): "c_wchar",
     ("ptrdiff_t", True, 0): "c_ptrdiff_t",  # Requires definition in preamble
     ("ssize_t", True, 0): "c_ptrdiff_t",  # Requires definition in preamble


### PR DESCRIPTION
These seem to be custom types from the APR library, which don't belong in a generic type map.

I descended git blame, but the lines in question predate the main history. Given commit 3d2d980, I'd guess APR may have been @davidjamesca's use case.

This is a backport of https://github.com/pypdfium2-team/ctypesgen/commit/fd31029e9f344131eb0f1fa5f55231741b5a0c16