### PR TITLE
style: Manual fixes for single-line-implicit-string-concatenation violations (ISC001)

### DIFF
--- a/ctypesgen/expressions.py
+++ b/ctypesgen/expressions.py
@@ -135,7 +135,7 @@ class UnaryExpressionNode(ExpressionNode):
         if self.op:
             return self.op(self.child.evaluate(context))
         else:
-            raise ValueError('The C operator "%s" can\'t be evaluated right ' "now" % self.name)
+            raise ValueError('The C operator "%s" can\'t be evaluated right now' % self.name)
 
     def py_string(self, can_be_ctype):
         return self.format % self.child.py_string(self.child_can_be_ctype and can_be_ctype)
@@ -182,7 +182,7 @@ class BinaryExpressionNode(ExpressionNode):
         if self.op:
             return self.op(self.left.evaluate(context), self.right.evaluate(context))
         else:
-            raise ValueError('The C operator "%s" can\'t be evaluated right ' "now" % self.name)
+            raise ValueError('The C operator "%s" can\'t be evaluated right now' % self.name)
 
     def py_string(self, can_be_ctype):
         return self.format % (


### PR DESCRIPTION
This PR is simply upstreaming the changes ctypesgen from an equivalent PR https://github.com/OSGeo/grass/pull/3943 and https://github.com/OSGeo/grass/pull/3944 in order to reduce the pylint violations to allow Pylint 3.x to run correctly on the GRASS repo.

Applying black 5 years ago seemed to have introduced this.
https://github.com/ctypesgen/ctypesgen/commit/1c0952a108d743d9e6e62eebe462f0ddd6d86588#diff-eaf194ce92079ba22ef6ec9b499537e4466d84e3bee0c9a7d4c1476719f810a9R139