### PR TITLE
Add 'bool' to ctypes type map, needed for C23

### DIFF
--- a/ctypesgen/ctypedescs.py
+++ b/ctypesgen/ctypedescs.py
@@ -58,6 +58,7 @@ ctypes_type_map = {
     ("__uint64", False, 0): "c_uint64",
     ("__uint64_t", False, 0): "c_uint64",
     ("_Bool", True, 0): "c_bool",
+    ("bool", True, 0): "c_bool",
 }
 
 ctypes_type_map_python_builtin = {


### PR DESCRIPTION
Add `bool` to ctypes type map. This change is needed for C23 support, where `_Bool` is not necessarily defined by default.

See e.g., [GCC](https://gcc.gnu.org/onlinedocs/gcc/Boolean-Type.html):

>C23 added bool as the preferred name of the boolean type, but _Bool also remains a standard keyword in the language and is supported as such by GCC with -std=c23.

GCC 15 now [defaults](https://gcc.gnu.org/gcc-15/changes.html#c) to C23.

Closes #173